### PR TITLE
CornerRadius binding support

### DIFF
--- a/DialogHost.Avalonia/DialogHost.axaml
+++ b/DialogHost.Avalonia/DialogHost.axaml
@@ -23,8 +23,9 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="DialogMargin" Value="8" />
-        <Setter Property="OverlayBackground" Value="Black"></Setter>
-        <Setter Property="dialogHost:DialogHostStyle.CornerRadius" Value="2"></Setter>
+        <Setter Property="OverlayBackground" Value="Black" />
+        <Setter Property="dialogHost:DialogHostStyle.ClipToBounds" Value="False" />        
+        <Setter Property="dialogHost:DialogHostStyle.CornerRadius" Value="2" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid Name="DialogHostRoot" Focusable="False">
@@ -57,7 +58,8 @@
             <ControlTemplate>
                 <Border Name="PART_ContentBackground" 
                         CornerRadius="{Binding Path=(dialogHost:DialogHostStyle.CornerRadius), RelativeSource={RelativeSource FindAncestor, AncestorType=dialogHost:DialogHost}}"
-                        BoxShadow="1.5 1.5 8 #4c000000" ClipToBounds="False">
+                        BoxShadow="1.5 1.5 8 #4c000000"
+                        ClipToBounds="{Binding Path=(dialogHost:DialogHostStyle.ClipToBounds), RelativeSource={RelativeSource FindAncestor, AncestorType=dialogHost:DialogHost}}">
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Background="{TemplateBinding Background}"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/DialogHost.Avalonia/DialogHostStyle.cs
+++ b/DialogHost.Avalonia/DialogHostStyle.cs
@@ -1,28 +1,57 @@
 ﻿using Avalonia;
 
-namespace DialogHost {
-    public class DialogHostStyle {
+namespace DialogHost
+{
+    public class DialogHostStyle
+    {
         /// <summary>
         /// Controls CornerRadius DialogHost's popup background.
         /// Works only for default DialogHost theme!
         /// </summary>
-        public static readonly AttachedProperty<CornerRadius> CornerRadiusProperty = 
+        public static readonly AttachedProperty<CornerRadius> CornerRadiusProperty =
             AvaloniaProperty.RegisterAttached<DialogHostStyle, DialogHost, CornerRadius>("CornerRadius");
+
+        /// <summary>
+        /// Controls ClipToBounds DialogHost's popup background.
+        /// Works only for default DialogHost theme!
+        /// </summary>
+        public static readonly AttachedProperty<bool> ClipToBoundsProperty =
+            AvaloniaProperty.RegisterAttached<DialogHostStyle, DialogHost, bool>("ClipToBounds");
 
         /// <summary>
         /// Get CornerRadius in DialogHost's popup background.
         /// Works only for default DialogHost theme!
         /// </summary>
-        public static CornerRadius GetCornerRadius(DialogHost element) {
+        public static CornerRadius GetCornerRadius(DialogHost element)
+        {
             return element.GetValue(CornerRadiusProperty);
+        }
+
+        /// <summary>
+        /// Get ClipToBounds in DialogHost's popup background.
+        /// Works only for default DialogHost theme!
+        /// </summary>
+        public static bool GetClipToBounds(DialogHost element)
+        {
+            return element.GetValue(ClipToBoundsProperty);
         }
 
         /// <summary>
         /// Set CornerRadius in DialogHost's popup background.
         /// Works only for default DialogHost theme!
         /// </summary>
-        public static void SetCornerRadius(DialogHost element, CornerRadius value) {
+        public static void SetCornerRadius(DialogHost element, CornerRadius value)
+        {
             element.SetValue(CornerRadiusProperty, value);
+        }
+
+        /// <summary>
+        /// Set ClipToBounds in DialogHost's popup background.
+        /// Works only for default DialogHost theme!
+        /// </summary>
+        public static void SetClipToBounds(DialogHost element, bool value)
+        {
+            element.SetValue(ClipToBoundsProperty, value);
         }
     }
 }


### PR DESCRIPTION
Without fix:
![image](https://user-images.githubusercontent.com/7500203/200153218-0f0f57e3-cb9c-4a79-81d8-5e8fd884063f.png)

With fix:
![image](https://user-images.githubusercontent.com/7500203/200153254-d37a33e4-0774-46bd-9954-c3eeaf7061e4.png)

Used:
- Material.Avalonia
- ColorZone from Material.Styles.Controls
- Tested on `CornerRadius="20"`