### PR TITLE
Expose BorderBrushProperty and BorderThicknessProperty properties

### DIFF
--- a/DialogHost.Avalonia/DialogHost.axaml
+++ b/DialogHost.Avalonia/DialogHost.axaml
@@ -58,6 +58,8 @@
     <Setter Property="PopupTemplate">
       <ControlTemplate>
         <Border Name="PART_ContentBackground"
+                BorderBrush="{Binding Path=(dialogHostAvalonia:DialogHostStyle.BorderBrush), RelativeSource={RelativeSource FindAncestor, AncestorType=dialogHostAvalonia:DialogHost}}"
+                BorderThickness="{Binding Path=(dialogHostAvalonia:DialogHostStyle.BorderThickness), RelativeSource={RelativeSource FindAncestor, AncestorType=dialogHostAvalonia:DialogHost}}"
                 CornerRadius="{Binding Path=(dialogHostAvalonia:DialogHostStyle.CornerRadius), RelativeSource={RelativeSource FindAncestor, AncestorType=dialogHostAvalonia:DialogHost}}"
                 BoxShadow="1.5 1.5 8 #4c000000"
                 ClipToBounds="{Binding Path=(dialogHostAvalonia:DialogHostStyle.ClipToBounds), RelativeSource={RelativeSource FindAncestor, AncestorType=dialogHostAvalonia:DialogHost}}"

--- a/DialogHost.Avalonia/DialogHostStyle.cs
+++ b/DialogHost.Avalonia/DialogHostStyle.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Media;
 
 namespace DialogHostAvalonia {
     public class DialogHostStyle {
@@ -15,6 +16,20 @@ namespace DialogHostAvalonia {
         /// </summary>
         public static readonly AttachedProperty<bool> ClipToBoundsProperty =
             AvaloniaProperty.RegisterAttached<DialogHostStyle, DialogHost, bool>("ClipToBounds");
+
+        /// <summary>
+        /// Controls BorderBrush DialogHost's popup background.
+        /// Works only for default DialogHost theme!
+        /// </summary>
+        public static readonly AttachedProperty<IBrush> BorderBrushProperty =
+            AvaloniaProperty.RegisterAttached<DialogHostStyle, DialogHost, IBrush>("BorderBrush");
+
+        /// <summary>
+        /// Controls BorderThickness DialogHost's popup background.
+        /// Works only for default DialogHost theme!
+        /// </summary>
+        public static readonly AttachedProperty<Thickness> BorderThicknessProperty =
+            AvaloniaProperty.RegisterAttached<DialogHostStyle, DialogHost, Thickness>("BorderThickness");
 
         /// <summary>
         /// Get CornerRadius in DialogHost's popup background.
@@ -50,6 +65,24 @@ namespace DialogHostAvalonia {
         public static void SetClipToBounds(DialogHost element, bool value)
         {
             element.SetValue(ClipToBoundsProperty, value);
+        }
+
+        /// <summary>
+        /// Set BorderBrush in DialogHost's popup background.
+        /// Works only for default DialogHost theme!
+        /// </summary>
+        public static void SetBorderBrush(DialogHost element, IBrush value)
+        {
+            element.SetValue(BorderBrushProperty, value);
+        }
+
+        /// <summary>
+        /// Set BorderThickness in DialogHost's popup background.
+        /// Works only for default DialogHost theme!
+        /// </summary>
+        public static void SetBorderThickness(DialogHost element, double value)
+        {
+            element.SetValue(BorderThicknessProperty, value);
         }
     }
 }


### PR DESCRIPTION
Expose BorderBrushProperty and BorderThicknessProperty for library consumers that want to override the dialog style.