### PR TITLE
Use compiled bindings by default

### DIFF
--- a/DialogHost.Avalonia/DialogHost.Avalonia.csproj
+++ b/DialogHost.Avalonia/DialogHost.Avalonia.csproj
@@ -17,6 +17,7 @@
         <PackageTags>c-sharp xaml multi-platform gui control mvvm dialogs avalonia avaloniaui c-sharp-library</PackageTags>
         <Version>0.7.2</Version>
         <RootNamespace>DialogHostAvalonia</RootNamespace>
+        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <PackageReleaseNotes>
 - Fix Dialog is still present in the visual tree after second opening #30
         </PackageReleaseNotes>


### PR DESCRIPTION
This helps with trimming compatibility which is needed with nativeaot. I didn't even needed to do anything to enable this, it just worked including all the demo project.

It removes all the trim warning generated as well as having the benefits of having compiler checked bindings.