### PR TITLE
Updated to Avalonia 11.0

### DIFF
--- a/DialogHost.Avalonia/DialogHost.Avalonia.csproj
+++ b/DialogHost.Avalonia/DialogHost.Avalonia.csproj
@@ -32,7 +32,7 @@
         </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-rc2.1"/>
+        <PackageReference Include="Avalonia" Version="11.0.0"/>
         <PackageReference Include="System.Reactive" Version="6.0.0"/>
     </ItemGroup>
 </Project>

--- a/DialogHost.Demo/DialogHost.Demo.csproj
+++ b/DialogHost.Demo/DialogHost.Demo.csproj
@@ -10,11 +10,11 @@
         <AvaloniaResource Include="Assets\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-rc2.1" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.0-rc2.1" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-rc2.1" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-rc2.1" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc2.1" />
+        <PackageReference Include="Avalonia" Version="11.0.2" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.2" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.2" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.2" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.2" />
         <PackageReference Include="Material.Icons.Avalonia" Version="2.0.1" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
There current 0.7.5 nuget package only targets avalonia 11 rc21 which is marked deprecated on nuget, this updates the DialogHost.Avalonia to 11.0.0 (as per Avalonia team libraries should target latest stabel non-patch version) and the demo to the latest 11.0.2