### PR TITLE
Rework dialog closing on IsOpen = false

### DIFF
--- a/DialogHost.Avalonia/DialogClosingEventArgs.cs
+++ b/DialogHost.Avalonia/DialogClosingEventArgs.cs
@@ -6,11 +6,25 @@ namespace DialogHostAvalonia;
 /// <summary>
 /// Event args contains info about dialog closing
 /// </summary>
-public class DialogClosingEventArgs(DialogSession session, RoutedEvent routedEvent) : RoutedEventArgs(routedEvent) {
+public class DialogClosingEventArgs(DialogSession session, RoutedEvent routedEvent, bool canBeCancelled)
+    : RoutedEventArgs(routedEvent) {
+    /// <inheritdoc />
+    [Obsolete("Use constructor with canBeCancelled parameter")]
+    public DialogClosingEventArgs(DialogSession session, RoutedEvent routedEvent) : this(session, routedEvent, true) {
+    }
+
     /// <summary>
     /// Cancel the close.
     /// </summary>
-    public void Cancel() => IsCancelled = true;
+    public void Cancel() {
+        if (!CanBeCancelled) {
+            throw new InvalidOperationException(
+                $"Cannot cancel dialog closing after {nameof(DialogHost)}.{nameof(DialogHost.IsOpen)} " +
+                $"property has been set to {bool.FalseString}");
+        }
+
+        IsCancelled = true;
+    }
 
     /// <summary>
     /// Indicates if the close has already been cancelled.
@@ -26,4 +40,12 @@ public class DialogClosingEventArgs(DialogSession session, RoutedEvent routedEve
     /// Allows interaction with the current dialog session.
     /// </summary>
     public DialogSession Session { get; } = session ?? throw new ArgumentNullException(nameof(session));
+
+    /// <summary>
+    /// Indicates if the close can be canceled.
+    /// </summary>
+    /// <remarks>
+    /// Typically this is <c>true</c> unless closing is triggered by setting <see cref="DialogHost.IsOpen"/> to <c>false</c>.
+    /// </remarks>
+    public bool CanBeCancelled { get; } = canBeCancelled;
 }

--- a/DialogHost.Avalonia/DialogSession.cs
+++ b/DialogHost.Avalonia/DialogSession.cs
@@ -58,7 +58,7 @@ public class DialogSession {
     {
         if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
-        _owner.InternalClose(this, null);
+        _owner.InternalClose(this, null, true);
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public class DialogSession {
     {
         if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
-        _owner.InternalClose(this, parameter);
+        _owner.InternalClose(this, parameter, true);
     }
 
     internal void ShowOpened(object obj, DialogOpenedEventArgs args) {


### PR DESCRIPTION
- Add `CanBeCancelled` property to `DialogClosingEventArgs`
- Move cancellable check to `DialogClosingEventArgs.Cancel()` method
- Simplify (and potentially fix) host removing logic when all dialogs are closed by `DialogHost.IsOpen = false`